### PR TITLE
Removed "Failing Test" Headers for Builds with Zero Failures

### DIFF
--- a/generators/GitHubIssueGenerator.py
+++ b/generators/GitHubIssueGenerator.py
@@ -381,11 +381,14 @@ Example Usages:
     
     def generate_body(self):
         """Generates a summary of our failing tests and their console/error messages."""
-        _body = "## Failing Tests\n\n"
-        _results = self.aggregated_results.get_results()
-        for _result in _results:
-            if _result['state'] == ra.ResultsAggregator.failed or _result['state'] == ra.ResultsAggregator.ignored:
-                _body = _body + f"### {GitHubIssueGenerator.status_symbols[_result['state']]} {_result['testsuite']} -> {_result['name']}\n\n"
-                _body = _body + f"```\n{_result['metadata']['message']}\n```\n"
+        _body = ""
+        _total, _passed, _failed, _skipped, _ignored = self.aggregated_results.get_counts()
+        if _failed > 0:
+            _body = "## Failing Tests\n\n"
+            _results = self.aggregated_results.get_results()
+            for _result in _results:
+                if _result['state'] == ra.ResultsAggregator.failed or _result['state'] == ra.ResultsAggregator.ignored:
+                    _body = _body + f"### {GitHubIssueGenerator.status_symbols[_result['state']]} {_result['testsuite']} -> {_result['name']}\n\n"
+                    _body = _body + f"```\n{_result['metadata']['message']}\n```\n"
         return _body
     

--- a/generators/MarkdownGenerator.py
+++ b/generators/MarkdownGenerator.py
@@ -252,11 +252,14 @@ Example Usages:
     
     def generate_body(self):
         """Generate a list of all failed or ignored tests and their associated messages, including all details."""
-        _body = "## Failing Tests\n\n"
-        _results = self.aggregated_results.get_results()
-        for _result in _results:
-            if _result['state'] == ra.ResultsAggregator.failed or _result['state'] == ra.ResultsAggregator.ignored:
-                _body = _body + f"### {MarkdownGenerator.status_symbols[_result['state']]} {_result['testsuite']} -> {_result['name']}\n\n"
-                _body = _body + f"```\n{_result['metadata']['message']}\n```\n"
+        _body = ""
+        _total, _passed, _failed, _skipped, _ignored = self.aggregated_results.get_counts()
+        if _failed > 0:
+            _body = _body + "## Failing Tests\n\n"
+            _results = self.aggregated_results.get_results()
+            for _result in _results:
+                if _result['state'] == ra.ResultsAggregator.failed or _result['state'] == ra.ResultsAggregator.ignored:
+                    _body = _body + f"### {MarkdownGenerator.status_symbols[_result['state']]} {_result['testsuite']} -> {_result['name']}\n\n"
+                    _body = _body + f"```\n{_result['metadata']['message']}\n```\n"
         return _body
  

--- a/generators/SlackGenerator.py
+++ b/generators/SlackGenerator.py
@@ -243,7 +243,9 @@ Example Usages:
     def generate_body_full(self):
         """Generates a full slack results body - this edition of the slack message body includes console output for failing test cases."""
         _body = ""
-        if self.aggregated_results.get_status(executed_gate=self.executed_quality_gate, passing_gate=self.passing_quality_gate) == ra.ResultsAggregator.failed:
+        _total, _passed, _failed, _skipped, _ignored = self.aggregated_results.get_counts()
+        if (self.aggregated_results.get_status(executed_gate=self.executed_quality_gate, passing_gate=self.passing_quality_gate) == ra.ResultsAggregator.failed
+            and _failed > 0):
             _body = "*Failing Tests*\n"
             _results = self.aggregated_results.get_results()
             for _result in _results:


### PR DESCRIPTION
## Summary of Changes

Now that we have different execution and passing gates, we can fail a build even if there were 0 failures (namely if too large a percentage of tests were skipped) - so we need to handle this case elegantly.  