### PR TITLE
Add issue chatter to slack messaging for issue 15737

### DIFF
--- a/canary-dedup-seeder.sh
+++ b/canary-dedup-seeder.sh
@@ -22,7 +22,7 @@ process_canary () {
         MINUTE=$(echo $SNAPSHOT | awk -F"-" -s {'print $7'})
         SECOND=$(echo $SNAPSHOT | awk -F"-" -s {'print $8'})
         echo $CLUSTER_DETAILS > .icd.json
-        python3 reporter.py gh --dry-run $BASE_PATH -sn $SNAPSHOT -hv $HUB_VERSION -hp $HUB_PLATFORM -ic .icd.json
+        python3 reporter.py gh -nocd -psd $BASE_PATH -sn $SNAPSHOT -hv $HUB_VERSION -hp $HUB_PLATFORM -r cicd-staging -ic .icd.json
         rm .icd.json
     else
         SNAPSHOT=`basename $BASE_PATH`

--- a/canary-dedup-seeder.sh
+++ b/canary-dedup-seeder.sh
@@ -22,7 +22,7 @@ process_canary () {
         MINUTE=$(echo $SNAPSHOT | awk -F"-" -s {'print $7'})
         SECOND=$(echo $SNAPSHOT | awk -F"-" -s {'print $8'})
         echo $CLUSTER_DETAILS > .icd.json
-        python3 reporter.py gh -nocd -psd $BASE_PATH -sn $SNAPSHOT -hv $HUB_VERSION -hp $HUB_PLATFORM -r cicd-staging -ic .icd.json
+        python3 reporter.py gh --dry-run $BASE_PATH -sn $SNAPSHOT -hv $HUB_VERSION -hp $HUB_PLATFORM -ic .icd.json
         rm .icd.json
     else
         SNAPSHOT=`basename $BASE_PATH`

--- a/generators/GitHubIssueGenerator.py
+++ b/generators/GitHubIssueGenerator.py
@@ -288,7 +288,6 @@ Example Usages:
                     github_id = self.open_github_issue_per_squad(_tags, squad)
                     if github_id == None:
                         github_id = "seed{}".format(randrange(100000,999999))
-                    print(f"Unique issue, adding github id {github_id} severity '{GitHubIssueGenerator.severities[_highest_sev]}' and priority '{GitHubIssueGenerator.priorities[_highest_pri]}' for squad:{squad}.", file=sys.stderr, flush=False)
                     # Needed because "Object of type datetime is not JSON serializable"
                     _now = "{}".format(datetime.utcnow())
                     _hv = "Unknown" if self.hub_version == None else self.hub_version
@@ -296,7 +295,7 @@ Example Usages:
                     entry = {"github_id":github_id, "first_snapshot":_sh, "hub_version":_hv, "hub_platform":_hp, "import_cluster_details":self.import_cluster_details, "status":"open","severity":GitHubIssueGenerator.severities[_highest_sev],"priority":GitHubIssueGenerator.priorities[_highest_pri],"date":_now,"squad_tag":"squad:{}".format(squad),"payload":_flat_issue_set}
                     print(f"Return code from database insert: {db_utils.insert_canary_issue(entry, self.github_repo[0])}", file=sys.stderr, flush=False)
                 else:
-                    print(f"squad:{squad} is a duplicate of issue {dup}.", file=sys.stderr, flush=False)
+                    print("squad:{} test failures are a duplicate of github issue {}.".format(squad, dup))
         db_utils.disconnect_from_db()
 
     def open_github_issue_per_squad(self, _tags, squad):
@@ -328,7 +327,7 @@ Example Usages:
                     pass
             _issue_title = "{}:{}".format(self.generate_issue_title(),squad)
             _issue = repo.create_issue(_issue_title, body=_message, labels=_github_tags_objects, assignees=_assignees)
-            print(_issue.html_url)
+            print("squad:{} opened issue URL: {}".format(squad, _issue.html_url))
             return _issue.number
         else:
             print(f"--dry-run or --no-per-squad-defect has been set, skipping squad's git issue creation", file=sys.stderr, flush=False)

--- a/generators/SlackGenerator.py
+++ b/generators/SlackGenerator.py
@@ -209,9 +209,9 @@ Example Usages:
             elif import_cluster['platform']:
                 _metadata = _metadata + f"• *Import Cluster Platform:* {import_cluster['platform']}\n"
         _metadata = _metadata + "\n"
-        # Include a link to the git issue where available
+        # Include github issue processing information if available
         if self.issue_url is not None:
-            _metadata = _metadata + f"*Opened Issue URL:* {self.issue_url}\n"
+            _metadata = _metadata + f"*Issue generation information:* {self.issue_url}\n"
         return _metadata
 
 

--- a/test/testSlackGenerator.py
+++ b/test/testSlackGenerator.py
@@ -55,7 +55,7 @@ class TestSlackGenerator(unittest.TestCase):
 • *Import Cluster Platform:* aws    *Import Cluster Version:* 4.7.0
 • *Import Cluster Platform:* gcp    *Import Cluster Version:* 4.7.1
 
-*Opened Issue URL:* TEST_ISSUE_URL
+*Issue generation information:* TEST_ISSUE_URL
 
 *Quality Gates (100% ; 100%):*
 :red_jenkins_circle:*92.31% Executed ; 75.0% Passing*
@@ -138,7 +138,7 @@ https://on.cypress.io/element-cannot-be-interacted-with
 • *Import Cluster Platform:* aws    *Import Cluster Version:* 4.7.0
 • *Import Cluster Platform:* gcp    *Import Cluster Version:* 4.7.1
 
-*Opened Issue URL:* TEST_ISSUE_URL
+*Issue generation information:* TEST_ISSUE_URL
 
 *Quality Gates (100% ; 100%):*
 :red_jenkins_circle:*92.31% Executed ; 75.0% Passing*


### PR DESCRIPTION
"GitHub Issue URL" is no longer a single thing; we now have zero or more messages relating to actions that occurred with a canary.