### PR TITLE
Put Issue generation chatter on its own line

### DIFF
--- a/generators/SlackGenerator.py
+++ b/generators/SlackGenerator.py
@@ -211,7 +211,7 @@ Example Usages:
         _metadata = _metadata + "\n"
         # Include github issue processing information if available
         if self.issue_url is not None:
-            _metadata = _metadata + f"*Issue generation information:* {self.issue_url}\n"
+            _metadata = _metadata + f"*Issue generation information:*\n{self.issue_url}\n"
         return _metadata
 
 

--- a/test/testSlackGenerator.py
+++ b/test/testSlackGenerator.py
@@ -55,7 +55,8 @@ class TestSlackGenerator(unittest.TestCase):
 • *Import Cluster Platform:* aws    *Import Cluster Version:* 4.7.0
 • *Import Cluster Platform:* gcp    *Import Cluster Version:* 4.7.1
 
-*Issue generation information:* TEST_ISSUE_URL
+*Issue generation information:*
+TEST_ISSUE_URL
 
 *Quality Gates (100% ; 100%):*
 :red_jenkins_circle:*92.31% Executed ; 75.0% Passing*
@@ -138,7 +139,8 @@ https://on.cypress.io/element-cannot-be-interacted-with
 • *Import Cluster Platform:* aws    *Import Cluster Version:* 4.7.0
 • *Import Cluster Platform:* gcp    *Import Cluster Version:* 4.7.1
 
-*Issue generation information:* TEST_ISSUE_URL
+*Issue generation information:*
+TEST_ISSUE_URL
 
 *Quality Gates (100% ; 100%):*
 :red_jenkins_circle:*92.31% Executed ; 75.0% Passing*


### PR DESCRIPTION
The slack output looks a little sloppy with the issue chatter starting on the same line as the heading, so start it out on its own line.